### PR TITLE
Performance improvements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,8 @@
     ],
     "require": {
         "php": "~7.0",
-        "nategood/commando": "^0.2.8"
+        "nategood/commando": "^0.2.8",
+        "halaxa/json-machine": "^0.3.2"
     },
     "bin": [
         "bin/github-changelog-generator"

--- a/src/ChangelogGenerator.php
+++ b/src/ChangelogGenerator.php
@@ -109,7 +109,7 @@ use DateTime;
       */
      private function collectReleaseIssues(DateTimeInterface $startDate = null): array
      {
-         $releases = $this->repository->getReleases();
+         $releases = iterator_to_array($this->repository->getReleases());
 
          if (empty($releases)) {
              throw new Exception('No releases found for this repository');
@@ -143,7 +143,7 @@ use DateTime;
      private function collectIssues(DateTimeInterface $lastReleaseDate = null): array
      {
          if (!$this->currentIssues) {
-             $this->currentIssues = $this->repository->getIssues(['state' => 'closed']);
+             $this->currentIssues = iterator_to_array($this->repository->getIssues(['state' => 'closed']));
          }
 
          $issues = [];

--- a/src/ChangelogGenerator.php
+++ b/src/ChangelogGenerator.php
@@ -160,17 +160,12 @@ use DateTime;
 
                  if ($type) {
                      $events = $this->repository->getIssueEvents($issue->number);
-                     $isMerged = false;
 
                      foreach ($events as $event) {
                          if (in_array($event->event, self::$supportedEvents) && !empty($event->commit_id)) {
-                             $isMerged = true;
+                             $issues[$type][] = $issue;
                              break;
                          }
-                     }
-
-                     if ($isMerged) {
-                         $issues[$type][] = $issue;
                      }
                  }
              }

--- a/src/ChangelogGenerator.php
+++ b/src/ChangelogGenerator.php
@@ -195,7 +195,7 @@ use DateTime;
      private function getTypeFromLabels(array $labels)
      {
          foreach ($labels as $label) {
-             if ($foundLabel = $this->getTypeFromLabel($label->name)) {
+             if ($foundLabel = $this->getTypeFromLabel($label->name, $this->issueLabelMapping)) {
                  return $foundLabel;
              }
          }
@@ -211,10 +211,8 @@ use DateTime;
       *
       * @return mixed [description]
       */
-     private function getTypeFromLabel(string $label, array $haystack = null)
+     private function getTypeFromLabel(string $label, array $haystack)
      {
-        $haystack = !$haystack ? $this->issueLabelMapping : $haystack;
-
         foreach ($haystack as $key => $value) {
             $current_key = $key;
 

--- a/src/Repository.php
+++ b/src/Repository.php
@@ -174,6 +174,8 @@ class Repository
      */
     private function fetch(string $url): Generator
     {
+        set_time_limit(15);     // prevent timeouts - time limit is reset on every recursive call
+
         $response = fopen($url, 'r', false, $this->context);
 
         if (!$response) {

--- a/src/Repository.php
+++ b/src/Repository.php
@@ -7,11 +7,9 @@ use Generator;
 use RuntimeException;
 
 /**
- * A simple class for working with GitHub's "Issues" API.
+ * A simple class for fetching data from a single GitHub repository.
  *
- * @see https://developer.github.com/v3/issues/
- *
- * @version 0.2.1
+ * @link https://developer.github.com/v3/
  * @author Marco Rieger (ins0)
  * @author Nathan Bishop (nbish11) (Contributor and Refactorer)
  * @copyright (c) 2015 Marco Rieger
@@ -20,7 +18,7 @@ use RuntimeException;
 class Repository
 {
     /**
-     * The root URL/domain to GitHub's API.
+     * The domain to GitHub's API.
      *
      * @var string
      */
@@ -34,27 +32,25 @@ class Repository
     const USER_AGENT = 'github-changelog-generator';
 
     /**
-     * Stores the full URL to the GitHub v3 API "repos" resource.
+     * The domain and path to the user's repository.
      *
      * @var string
      */
     private $url;
 
     /**
-     * The GitHub OAUTH token to use, if provided.
+     * Additional information sent along with the request.
      *
-     * @var string
+     * @var resource
      */
     private $context;
 
     /**
      * Constructs a new instance.
      *
-     * @param string $repository The username and repository
-     *                           provided in the following
-     *                           format: ":username/:repository".
-     * @param string $token      An optional OAUTH token for
-     *                           authentication.
+     * @param string $repository The username and repository in the following format: ":username/:repository".
+     * @param string|null $token The OAUTH token used to validate against GithHub's API.
+     * @throws InvalidArgumentException If the path to the repository is not in the correct format.
      */
     public function __construct(string $repository, string $token = null)
     {
@@ -75,12 +71,9 @@ class Repository
     /**
      * Fetch all releases for the current repository.
      *
-     * @param array   $params Allows for advanced sorting.
-     * @param integer $page   Skip to a specific page.
-     *
-     * @return array Always returns an array, regardless of
-     *               whether or not there are any releases for
-     *               the current repository.
+     * @param mixed[] $params Supported parameters are: "page".
+     * @throws RuntimeException If a connection could not be established to the URL.
+     * @return Generator An iterator that gradually resolves with more data as it becomes available.
      */
     public function getReleases(array $params = []): Generator
     {
@@ -90,12 +83,10 @@ class Repository
     /**
      * Fetches all issues for the current repository.
      *
-     * @param array   $params Allows for advanced sorting.
-     * @param integer $page   Skip to a specific page.
-     *
-     * @return array Always returns an array, regardless of
-     *               whether or not there are any issues for
-     *               the current repository.
+     * @param mixed[] $params Supported parameters are: "page", "milestone", "state", "assignee",
+     *                        "creator", "mentioned", "labels", "sort", "direction" and "since".
+     * @throws RuntimeException If a connection could not be established to the URL.
+     * @return Generator An iterator that gradually resolves with more data as it becomes available.
      */
     public function getIssues(array $params = []): Generator
     {
@@ -105,9 +96,8 @@ class Repository
     /**
      * Fetch all labels for the current repository.
      *
-     * @return array Always returns an array, regardless of
-     *               whether or not there are any labels
-     *               for the current repository.
+     * @throws RuntimeException If a connection could not be established to the URL.
+     * @return Generator An iterator that gradually resolves with more data as it becomes available.
      */
     public function getLabels(): Generator
     {
@@ -115,12 +105,10 @@ class Repository
     }
 
     /**
-     * Fetch all available assignees, to which issues may be
-     * assigned to.
+     * Fetch all available assignees, to which issues may be assigned to.
      *
-     * @return array Always returns an array, regardless of
-     *               whether or not there are any assignees
-     *               for the current repository.
+     * @throws RuntimeException If a connection could not be established to the URL.
+     * @return Generator An iterator that gradually resolves with more data as it becomes available.
      */
     public function getAssignees(): Generator
     {
@@ -131,11 +119,9 @@ class Repository
      * Get all comments for a specific issue.
      *
      * @param integer $number The issue number.
-     * @param array   $params Allows for advanced sorting.
-     *
-     * @return array Always returns an array, regardless of
-     *               whether or not there are any comments for
-     *               the selected issue.
+     * @param mixed[] $params Supported parameters are: "page", sort", "direction" and "since".
+     * @throws RuntimeException If a connection could not be established to the URL.
+     * @return Generator An iterator that gradually resolves with more data as it becomes available.
      */
     public function getIssueComments(int $number, array $params = []): Generator
     {
@@ -146,10 +132,8 @@ class Repository
      * Get all events for a specific issue.
      *
      * @param integer $number The issue number.
-     *
-     * @return array Always returns an array, regardless of
-     *               whether or not there are any events for
-     *               the selected issue.
+     * @throws RuntimeException If a connection could not be established to the URL.
+     * @return Generator An iterator that gradually resolves with more data as it becomes available.
      */
     public function getIssueEvents(int $number): Generator
     {
@@ -160,10 +144,8 @@ class Repository
      * Get all labels attached to a specific issue.
      *
      * @param integer $number The issue number.
-     *
-     * @return array Always returns an array, regardless of
-     *               whether or not there are any labels for
-     *               the selected issue.
+     * @throws RuntimeException If a connection could not be established to the URL.
+     * @return Generator An iterator that gradually resolves with more data as it becomes available.
      */
     public function getIssueLabels(int $number): Generator
     {
@@ -173,12 +155,9 @@ class Repository
     /**
      * Fetch all milestones for the current repository.
      *
-     * @param array   $params Allows for advanced sorting.
-     * @param integer $page   Skip to a specific page.
-     *
-     * @return [type] Always returns an array, regardless of
-     *                whether or not there are any milestones
-     *                for the current repository.
+     * @param mixed[] $params Supported parameters are: "page", "state", "sort" and "direction".
+     * @throws RuntimeException If a connection could not be established to the URL.
+     * @return Generator An iterator that gradually resolves with more data as it becomes available.
      */
     public function getMilestones(array $params = []): Generator
     {
@@ -186,13 +165,11 @@ class Repository
     }
 
     /**
-     * [fetch description]
+     * Make a request to one of GitHub's API endpoints and retrieve the response.
      *
-     * @param string  $call   [description]
-     * @param array   $params [description]
-     * @param integer $page   [description]
-     *
-     * @return object|array [description]
+     * @param string $url The full URL to the API resource.
+     * @throws RuntimeException If a connection could not be established to the URL.
+     * @return Generator An iterator that gradually resolves with more data as it becomes available.
      */
     private function fetch(string $url): Generator
     {
@@ -211,7 +188,7 @@ class Repository
     }
 
     /**
-     * [getNextPageFromLinkHeader description]
+     * Determine the "next" page from GitHub's pagination headers.
      *
      * @param string[] $responseHeaders The response headers of the last request sent.
      * @return string The URL of the next page or an empty string.

--- a/src/Repository.php
+++ b/src/Repository.php
@@ -5,6 +5,7 @@ namespace ins0\GitHub;
 use InvalidArgumentException;
 use Generator;
 use RuntimeException;
+use JsonMachine\JsonMachine;
 
 /**
  * A simple class for fetching data from a single GitHub repository.
@@ -173,13 +174,15 @@ class Repository
      */
     private function fetch(string $url): Generator
     {
-        $response = file_get_contents($url, false, $this->context);
+        $response = fopen($url, 'r', false, $this->context);
 
         if (!$response) {
             throw new RuntimeException(sprintf('Cannot connect to: %s', $url));
         }
 
-        yield from json_decode($response);
+        yield from JsonMachine::fromStream($response);
+
+        fclose($response);
 
         // "It's important to form calls with Link header values instead of constructing your own URLs." - GitHub
         if ($nextPage = $this->getNextPageFromLinkHeader($http_response_header)) {

--- a/src/Repository.php
+++ b/src/Repository.php
@@ -66,7 +66,7 @@ class Repository
         $headers = [sprintf('User-Agent: %s', self::USER_AGENT)];
 
         if ($token) {
-            $headers[] = [sprintf('Authorization: token %s', $token)];
+            $headers[] = sprintf('Authorization: token %s', $token);
         }
 
         $this->context = stream_context_create(['http' => ['header' => $headers]]);

--- a/tests/ChangelogGeneratorTest.php
+++ b/tests/ChangelogGeneratorTest.php
@@ -4,129 +4,128 @@ namespace ins0\GitHub;
 
 class ChangelogGeneratorTest extends TestSuite
 {
-	/**
-	 * @expectedException        Exception
-	 * @expectedExceptionMessage No releases found for this repository
-	 */
-	public function testThrowsExceptionIfNoReleasesAreFound()
-	{
-		$mockRepository = $this->getMockRepository();
+    /**
+     * @expectedException        Exception
+     * @expectedExceptionMessage No releases found for this repository
+     */
+    public function testThrowsExceptionIfNoReleasesAreFound()
+    {
+        $mockRepository = new MockRepository();
+        $changelogGenerator = new ChangelogGenerator($mockRepository);
 
-		$mockRepository->method('getReleases')->willReturn([]);
+        $changelog = $changelogGenerator->generate();
+    }
 
-		$changelogGenerator = new ChangelogGenerator($mockRepository);
-		$changelog = $changelogGenerator->generate();
-	}
+    public function testThatAReleaseWithNoIssuesGeneratesAnEmptyChangelog()
+    {
+        $mockRepository = new MockRepository();
+        $mockRepository->releases = $this->loadFixtureData('releases');
+        $changelogGenerator = new ChangelogGenerator($mockRepository);
 
-	public function testThatAReleaseWithNoIssuesGeneratesAnEmptyChangelog()
-	{
-		$mockRepository = $this->getMockRepositoryWithIssues([]);
-		$changelogGenerator = new ChangelogGenerator($mockRepository);
+        $this->assertEquals(
+            $this->loadFile('output/release-with-no-sections.md'),
+            $changelogGenerator->generate()
+        );
+    }
 
-		$this->assertEquals(
-			$this->loadFile('output/release-with-no-sections.md'),
-			$changelogGenerator->generate()
-		);
-	}
+    public function testIssuesAreOnlyPinnedToReleaseTags()
+    {
+        $mockRepository = $this->getMockRepositoryWithIssues($this->loadFixtureData('issues'));
+        $changelogGenerator = new ChangelogGenerator($mockRepository);
 
-	public function testIssuesAreOnlyPinnedToReleaseTags()
-	{
-		$mockRepository = $this->getMockRepositoryWithIssues($this->loadFixtureData('issues'));
-		$changelogGenerator = new ChangelogGenerator($mockRepository);
+        $this->assertEquals(
+            $this->loadFile('output/release-with-all-sections.md'),
+            $changelogGenerator->generate()
+        );
+    }
 
-		$this->assertEquals(
-			$this->loadFile('output/release-with-all-sections.md'),
-			$changelogGenerator->generate()
-		);
-	}
+    public function testGeneratesAChangedSectionUnderRelease()
+    {
+        // Only test issues 1 and 2 (tagged with 'enhancement')
+        $issues = $this->loadFixtureData('issues');
+        $mockRepository = $this->getMockRepositoryWithIssues([$issues[3], $issues[4]]);
+        $changelogGenerator = new ChangelogGenerator($mockRepository);
 
-	public function testGeneratesAChangedSectionUnderRelease()
-	{
-		// Only test issues 1 and 2 (tagged with 'enhancement')
-		$issues = $this->loadFixtureData('issues');
-		$mockRepository = $this->getMockRepositoryWithIssues([$issues[3], $issues[4]]);
-		$changelogGenerator = new ChangelogGenerator($mockRepository);
+        $this->assertEquals(
+            $this->loadFile('output/release-with-changed-only-section.md'),
+            $changelogGenerator->generate()
+        );
+    }
 
-		$this->assertEquals(
-			$this->loadFile('output/release-with-changed-only-section.md'),
-			$changelogGenerator->generate()
-		);
-	}
+    public function testGeneratesAnAddedSectionUnderRelease()
+    {
+        // Only test issue 3 (tagged with 'feature')
+        $mockRepository = $this->getMockRepositoryWithIssues([$this->loadFixtureData('issues')[2]]);
+        $changelogGenerator = new ChangelogGenerator($mockRepository);
 
-	public function testGeneratesAnAddedSectionUnderRelease()
-	{
-		// Only test issue 3 (tagged with 'feature')
-		$mockRepository = $this->getMockRepositoryWithIssues([$this->loadFixtureData('issues')[2]]);
-		$changelogGenerator = new ChangelogGenerator($mockRepository);
+        $this->assertEquals(
+            $this->loadFile('output/release-with-added-only-section.md'),
+            $changelogGenerator->generate()
+        );
+    }
 
-		$this->assertEquals(
-			$this->loadFile('output/release-with-added-only-section.md'),
-			$changelogGenerator->generate()
-		);
-	}
+    public function testGeneratesAPullRequestsSectionUnderRelease()
+    {
+        // Only test issue 4 (no tags, marked as a 'pull request')
+        $mockRepository = $this->getMockRepositoryWithIssues([$this->loadFixtureData('issues')[1]]);
+        $changelogGenerator = new ChangelogGenerator($mockRepository);
 
-	public function testGeneratesAPullRequestsSectionUnderRelease()
-	{
-		// Only test issue 4 (no tags, marked as a 'pull request')
-		$mockRepository = $this->getMockRepositoryWithIssues([$this->loadFixtureData('issues')[1]]);
-		$changelogGenerator = new ChangelogGenerator($mockRepository);
+        $this->assertEquals(
+            $this->loadFile('output/release-with-pull-requests-only-section.md'),
+            $changelogGenerator->generate()
+        );
+    }
 
-		$this->assertEquals(
-			$this->loadFile('output/release-with-pull-requests-only-section.md'),
-			$changelogGenerator->generate()
-		);
-	}
+    public function testGeneratesAFixedSectionUnderRelease()
+    {
+        // Only test issue 5 (tagged with 'bug')
+        $mockRepository = $this->getMockRepositoryWithIssues([$this->loadFixtureData('issues')[0]]);
+        $changelogGenerator = new ChangelogGenerator($mockRepository);
 
-	public function testGeneratesAFixedSectionUnderRelease()
-	{
-		// Only test issue 5 (tagged with 'bug')
-		$mockRepository = $this->getMockRepositoryWithIssues([$this->loadFixtureData('issues')[0]]);
-		$changelogGenerator = new ChangelogGenerator($mockRepository);
+        $this->assertEquals(
+            $this->loadFile('output/release-with-fixed-only-section.md'),
+            $changelogGenerator->generate()
+        );
+    }
 
-		$this->assertEquals(
-			$this->loadFile('output/release-with-fixed-only-section.md'),
-			$changelogGenerator->generate()
-		);
-	}
+    public function testCanChooseCustomLabelForChangedSection()
+    {
+        $issues = $this->loadFixtureData('issues-with-custom-labels');
+        $issueMappings = [ChangelogGenerator::LABEL_TYPE_CHANGED => ['CustomEnhancementLabel']];
+        $mockRepository = $this->getMockRepositoryWithIssues([$issues[2], $issues[3]]);
+        $changelogGenerator = new ChangelogGenerator($mockRepository, $issueMappings);
 
-	public function testCanChooseCustomLabelForChangedSection()
-	{
-		$issues = $this->loadFixtureData('issues-with-custom-labels');
-		$issueMappings = [ChangelogGenerator::LABEL_TYPE_CHANGED => ['CustomEnhancementLabel']];
-		$mockRepository = $this->getMockRepositoryWithIssues([$issues[2], $issues[3]]);
-		$changelogGenerator = new ChangelogGenerator($mockRepository, $issueMappings);
+        $this->assertEquals(
+            $this->loadFile('output/release-with-changed-only-section.md'),
+            $changelogGenerator->generate()
+        );
+    }
 
-		$this->assertEquals(
-			$this->loadFile('output/release-with-changed-only-section.md'),
-			$changelogGenerator->generate()
-		);
-	}
+    public function testCanChooseCustomLabelForAddedSection()
+    {
+        $issues = $this->loadFixtureData('issues-with-custom-labels');
+        $issueMappings = [ChangelogGenerator::LABEL_TYPE_ADDED => ['CustomFeatureLabel']];
+        $mockRepository = $this->getMockRepositoryWithIssues([$issues[1]]);
+        $changelogGenerator = new ChangelogGenerator($mockRepository, $issueMappings);
 
-	public function testCanChooseCustomLabelForAddedSection()
-	{
-		$issues = $this->loadFixtureData('issues-with-custom-labels');
-		$issueMappings = [ChangelogGenerator::LABEL_TYPE_ADDED => ['CustomFeatureLabel']];
-		$mockRepository = $this->getMockRepositoryWithIssues([$issues[1]]);
-		$changelogGenerator = new ChangelogGenerator($mockRepository, $issueMappings);
+        $this->assertEquals(
+            $this->loadFile('output/release-with-added-only-section.md'),
+            $changelogGenerator->generate()
+        );
+    }
 
-		$this->assertEquals(
-			$this->loadFile('output/release-with-added-only-section.md'),
-			$changelogGenerator->generate()
-		);
-	}
+    public function testCanChooseCustomLabelForFixedSection()
+    {
+        $issues = $this->loadFixtureData('issues-with-custom-labels');
+        $issueMappings = [ChangelogGenerator::LABEL_TYPE_FIXED => ['CustomBugLabel']];
+        $mockRepository = $this->getMockRepositoryWithIssues([$issues[0]]);
+        $changelogGenerator = new ChangelogGenerator($mockRepository, $issueMappings);
 
-	public function testCanChooseCustomLabelForFixedSection()
-	{
-		$issues = $this->loadFixtureData('issues-with-custom-labels');
-		$issueMappings = [ChangelogGenerator::LABEL_TYPE_FIXED => ['CustomBugLabel']];
-		$mockRepository = $this->getMockRepositoryWithIssues([$issues[0]]);
-		$changelogGenerator = new ChangelogGenerator($mockRepository, $issueMappings);
-
-		$this->assertEquals(
-			$this->loadFile('output/release-with-fixed-only-section.md'),
-			$changelogGenerator->generate()
-		);
-	}
+        $this->assertEquals(
+            $this->loadFile('output/release-with-fixed-only-section.md'),
+            $changelogGenerator->generate()
+        );
+    }
 
     public function testCanOverrideTypeHeader()
     {
@@ -141,7 +140,7 @@ class ChangelogGeneratorTest extends TestSuite
         );
     }
 
-	public function testCanChooseCustomTypeHeader()
+    public function testCanChooseCustomTypeHeader()
     {
         $issues = $this->loadFixtureData('issues-with-custom-labels');
         $issueMappings = ['custom' => ['CustomBugLabel']];
@@ -155,36 +154,29 @@ class ChangelogGeneratorTest extends TestSuite
         );
     }
 
-	private function getMockRepositoryWithIssues(array $issues)
-	{
-		$mockRepository = $this->getMockRepository();
-
-		$mockRepository->method('getReleases')->willReturn($this->loadFixtureData('releases'));
-		$mockRepository->method('getIssues')->willReturn($issues);
-		$mockRepository->method('getIssueEvents')->will($this->returnValueMap([
-	    	[1, $this->loadFixtureData('issue1-events')],
-            [2, $this->loadFixtureData('issue2-events')],
-            [3, $this->loadFixtureData('issue3-events')],
-            [4, $this->loadFixtureData('issue4-events')],
-            [5, $this->loadFixtureData('issue5-events')]
-        ]));
+    private function getMockRepositoryWithIssues(array $issues)
+    {
+        $mockRepository = new MockRepository();
+        $mockRepository->releases = $this->loadFixtureData('releases');
+        $mockRepository->issues = $issues;
+        $mockRepository->issueEvents = [
+            1 => $this->loadFixtureData('issue1-events'),
+            2 => $this->loadFixtureData('issue2-events'),
+            3 => $this->loadFixtureData('issue3-events'),
+            4 => $this->loadFixtureData('issue4-events'),
+            5 => $this->loadFixtureData('issue5-events')
+        ];
 
         return $mockRepository;
-	}
+    }
 
-	private function getMockRepository()
-	{
-		return $this->getMockBuilder('ins0\\GitHub\\Repository')
-			->disableOriginalConstructor()->getMock();
-	}
+    private function loadFixtureData($fixture)
+    {
+        return json_decode($this->loadFile("fixtures/{$fixture}.json"));
+    }
 
-	private function loadFixtureData($fixture)
-	{
-		return json_decode($this->loadFile("fixtures/{$fixture}.json"));
-	}
-
-	private function loadFile($file)
-	{
-		return file_get_contents(__DIR__ . "/{$file}");
-	}
+    private function loadFile($file)
+    {
+        return file_get_contents(__DIR__ . "/{$file}");
+    }
 }

--- a/tests/MockRepository.php
+++ b/tests/MockRepository.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types=1);
+
+namespace ins0\GitHub;
+
+use Generator;
+
+/**
+ * Mocks responses from GitHub's API. Used for testing purposes only.
+ */
+final class MockRepository extends Repository
+{
+    public function __construct(string $repository = '', string $token = null)
+    {
+        $this->releases = [];
+        $this->issues = [];
+        $this->issueEvents = [];
+    }
+
+    public function getReleases(array $params = []): Generator
+    {
+        yield from $this->releases;
+    }
+
+    public function getIssues(array $params = []): Generator
+    {
+        yield from $this->issues;
+    }
+
+    public function getIssueEvents(int $number): Generator
+    {
+        yield from $this->issueEvents[$number];
+    }
+}


### PR DESCRIPTION
This PR only serves to pave the way to a full refactor using Generators. As it stands, the `ChangelogGenerator` class is just to messy to fully implement Generators in it (hence the use of the `iterator_to_array()` method).

There is still, however marginal, performance improvements in this PR (mainly in memory use). Also, less timeouts for repos with lots of releases.